### PR TITLE
fix: stop camelCasing parameter names in generated code

### DIFF
--- a/src/core/client/axios.ts
+++ b/src/core/client/axios.ts
@@ -93,11 +93,7 @@ export class AxiosAdapter extends Adapter {
 														t.createCallExpression(
 															t.createIdentifier('String'),
 															undefined,
-															[
-																t.createIdentifier(
-																	Base.camelCase(Base.normalize(p.name))
-																),
-															]
+															[t.createIdentifier(Base.normalize(p.name))]
 														),
 													]
 												)

--- a/src/core/client/fetch.ts
+++ b/src/core/client/fetch.ts
@@ -76,11 +76,7 @@ export class FetchAdapter extends Adapter {
 														t.createCallExpression(
 															t.createIdentifier('String'),
 															undefined,
-															[
-																t.createIdentifier(
-																	Base.camelCase(Base.normalize(p.name))
-																),
-															]
+															[t.createIdentifier(Base.normalize(p.name))]
 														),
 													]
 												)

--- a/src/core/generator/index.ts
+++ b/src/core/generator/index.ts
@@ -119,7 +119,7 @@ export class Generator {
 			const queryString = queryParameters
 				.map(
 					(qp, index) =>
-						`${index === 0 ? '?' : '&'}${encodeURIComponent(qp.name)}={${Base.camelCase(Base.normalize(qp.name))}}`
+						`${index === 0 ? '?' : '&'}${encodeURIComponent(qp.name)}={${Base.normalize(qp.name)}}`
 				)
 				.join('');
 			path += queryString;
@@ -144,7 +144,7 @@ export class Generator {
 				}
 
 				return t.createTemplateSpan(
-					t.createIdentifier(match[1]),
+					t.createIdentifier(Base.normalize(match[1])),
 					!isLastSegment
 						? t.createTemplateMiddle(match[2])
 						: t.createTemplateTail(match[2] || '')
@@ -239,7 +239,7 @@ export class Generator {
 		const tags: CommentObject[] = [];
 
 		for (const p of parameters) {
-			const paramName = Base.camelCase(Base.normalize(p.name));
+			const paramName = Base.normalize(p.name);
 			let paramType = 'unknown';
 
 			if (p.schema) {
@@ -428,7 +428,7 @@ export class Generator {
 					t.createParameterDeclaration(
 						undefined,
 						undefined,
-						t.createIdentifier(Base.camelCase(Base.normalize(refName))),
+						t.createIdentifier(Base.normalize(refName)),
 						undefined,
 						t.createTypeReferenceNode(
 							t.createIdentifier(Base.upperCamelCase(Base.normalize(refName)))
@@ -442,14 +442,14 @@ export class Generator {
 					t.createBindingElement(
 						undefined,
 						undefined,
-						t.createIdentifier(Base.camelCase(Base.normalize(name)))
+						t.createIdentifier(Base.normalize(name))
 					)
 				);
 
 				typeObjectElements.push(
 					t.createPropertySignature(
 						[],
-						t.createIdentifier(Base.camelCase(Base.normalize(name))),
+						t.createIdentifier(Base.normalize(name)),
 						required ? undefined : t.createToken(SyntaxKind.QuestionToken),
 						!schema
 							? t.createToken(SyntaxKind.UnknownKeyword)


### PR DESCRIPTION
## 问题

参数名如 `user_id` 在函数签名中被转换为 `userId`（通过 `Base.camelCase`），但在 URL 模板、form data、header 等引用处仍使用原始名 `user_id`，导致变量未定义错误。

## 修改

从所有参数名转换中移除 `camelCase`，仅保留 `normalize`（处理特殊字符和 TS 保留关键字）：

| 文件 | 变更 |
|------|------|
| `src/core/generator/index.ts` | `toUrlTemplate`（查询参数嵌入表达式）、`generateParamTags`（@param 标签）、`toDeclarationNodes`（函数参数声明和类型）、路径参数引用 |
| `src/core/client/fetch.ts` | 请求头参数值引用 |
| `src/core/client/axios.ts` | 请求头参数值引用 |

同时修复了一个隐藏问题：路径参数（如 `{object}` → `{object_}`）引用未经过 `normalize`，当参数名为 TS 关键字时会导致变量名不匹配。

## 测试

全部 199 个测试用例通过。