### PR TITLE
chore: bump version to 0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @moccona/apicodegen
 
+## 0.0.11
+
+### Patch Changes
+
+- fix: stop camelCasing parameter names in generated code
+
+  Parameter names like `user_id` were being converted to `userId` in function signatures, but referenced as `user_id` elsewhere, causing undefined variable errors. Remove camelCase from parameter name transformation, keeping only normalize.
+
 ## 0.0.10
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moccona/apicodegen",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "",
   "type": "module",
   "engines": {


### PR DESCRIPTION
版本 bump v0.0.10 → v0.0.11

## 变更

- fix: stop camelCasing parameter names in generated code (#9)