### PR TITLE
docs: align release flow between AGENTS.md and releasing skill

### DIFF
--- a/.agents/skills/releasing/SKILL.md
+++ b/.agents/skills/releasing/SKILL.md
@@ -7,7 +7,7 @@ description: Use when preparing to release a new version - releasing npm package
 
 ## Overview
 
-This project uses **changeset** with **GitHub Actions** for automated releases. Tag pushes trigger the release workflow which builds, creates GitHub release with CHANGELOG, and publishes to npm.
+This project uses **changeset** for versioning + CHANGELOG generation, and **GitHub Actions** for automated npm publishing. The release is triggered by creating a GitHub Release (which also creates the tag), not by pushing tags directly.
 
 ## When to Use
 
@@ -19,25 +19,33 @@ This project uses **changeset** with **GitHub Actions** for automated releases. 
 ## Release Flow
 
 ```
-1. Ensure changes are committed
-2. Create changeset file (describes what changed + bump type)
-3. Run changeset version locally (updates version in package.json + CHANGELOG.md)
-4. Commit version changes
-5. Push to main
-6. Create and push release tag
-7. GitHub Actions automatically: build → release → publish
+1. Ensure changes are committed on main
+2. Create feature branch: git checkout -b release/v<X.Y.Z>
+3. Create changeset: pnpm changeset add
+4. Run changeset version: pnpm changeset version
+5. Commit version changes
+6. Push branch and open PR
+7. User merges PR on GitHub
+8. Run: gh release create v<X.Y.Z>
+9. CI automatically: build → publish to npm
 ```
 
 ## Step-by-Step
 
-### 1. Check Status
+### 1. Start from main
 
 ```bash
-git status
-# All changes should be committed before release
+git checkout main
+git pull origin main
 ```
 
-### 2. Create Changeset
+### 2. Create Release Branch
+
+```bash
+git checkout -b release/v<X.Y.Z>
+```
+
+### 3. Create Changeset
 
 ```bash
 pnpm changeset add
@@ -51,7 +59,7 @@ When prompted:
   - `major` - Breaking changes
 - **Write description**: Brief summary of changes
 
-### 3. Update Version Locally
+### 4. Update Version Locally
 
 ```bash
 pnpm changeset version
@@ -61,68 +69,61 @@ This will:
 - Update `package.json` version
 - Update `CHANGELOG.md`
 
-### 4. Commit Version Changes
+### 5. Commit Version Changes
 
 ```bash
 git add .
-git commit -m "chore: bump version"
+git commit -m "chore: bump version to <X.Y.Z>"
 ```
 
-### 5. Push
+### 6. Push and Open PR
 
 ```bash
-git push origin main
+git push origin release/v<X.Y.Z>
+gh pr create --base main --head release/v<X.Y.Z> \
+  --title "chore: bump version to <X.Y.Z>" \
+  --body "版本 bump <previous> → <X.Y.Z>"
 ```
 
-### 6. Create Release Tag
+### 7. Merge PR
+
+User reviews and merges on GitHub.
+
+### 8. Create GitHub Release
+
+After PR is merged, locally on main:
 
 ```bash
-git tag v0.0.4        # Replace with your version (should match package.json)
-git push origin v0.0.4
+git checkout main && git pull origin main
+gh release create v<X.Y.Z> --generate-notes
 ```
 
-### 7. Verify Release
+This creates the git tag and triggers CI.
+
+### 9. Verify Release
 
 Check GitHub Actions tab for release workflow run. On success:
-- GitHub release created with CHANGELOG
 - Package published to npm
 
 ## Version Bump Guide
 
 | Type | When to Use | Example |
 |------|-------------|---------|
-| `patch` | Bug fixes | `v0.0.3` → `v0.0.4` |
-| `minor` | New features | `v0.0.4` → `v0.1.0` |
+| `patch` | Bug fixes | `v0.0.10` → `v0.0.11` |
+| `minor` | New features | `v0.0.11` → `v0.1.0` |
 | `major` | Breaking changes | `v0.1.0` → `v1.0.0` |
-
-## Skip Release
-
-To push to main without triggering release:
-
-```bash
-git commit -m "chore: skip release"
-git push
-```
-
-The workflow checks for "skip release" in commit message.
 
 ## Troubleshooting
 
-**Release didn't trigger?**
-- Verify tag format: `v*` (e.g., `v0.0.4`)
-- Check GitHub Actions logs
-- Ensure `package.json` version matches the tag
-
 **npm publish failed?**
-- Verify `NPM_TOKEN` secret exists in repo Settings → Secrets
+- Verify `NPM_TOKEN` secret exists in repo Settings → Secrets and variables → Actions
 - Check token has correct permissions
 
 **Version mismatch?**
-- Run `pnpm changeset version` locally before tagging
-- The `package.json` version must match the git tag version
-- If tag already exists with wrong version:
+- The `package.json` version must match the release tag
+- If tag is wrong, delete and retry:
   ```bash
-  git tag -d v0.0.4 && git tag v0.0.4 && git push origin v0.0.4 --force
+  git tag -d v<X.Y.Z> && gh release delete v<X.Y.Z}
   ```
 
 ## Quick Reference
@@ -130,8 +131,8 @@ The workflow checks for "skip release" in commit message.
 | Command | Purpose |
 |---------|---------|
 | `pnpm changeset add` | Create changeset |
-| `pnpm changeset version` | Update version in package.json + CHANGELOG.md (run locally before tagging) |
-| `pnpm changeset publish` | Release (runs in CI after tag push) |
+| `pnpm changeset version` | Update version + CHANGELOG |
+| `gh release create v<X.Y.Z> --generate-notes` | Create release + tag (triggers CI) |
 
 ## Required Setup (One-time)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Rules for AI coding agents working in this repository. These are **hard requirem
 ### Release flow
 
 - `main` has a ruleset that requires `pull_request` (no direct push).
-- For a new version: open a PR with the version bump + refactor; the user merges on GitHub; then locally run `gh release create v<X.Y.Z>` (which also creates the tag). CI handles `npm publish` on the release event.
+- For a new version: create a release branch (`release/v<X.Y.Z>`), run `pnpm changeset add` and `pnpm changeset version` to bump the version and update CHANGELOG, then open a PR; the user merges on GitHub; then locally run `gh release create v<X.Y.Z>` (which also creates the tag). CI handles `npm publish` on the release event.
 - Do not run `git tag ... && git push origin v*` without going through the release flow first.
 
 ### Do not modify branch protection / rulesets unless explicitly asked

--- a/src/vite-plugin/index.ts
+++ b/src/vite-plugin/index.ts
@@ -35,19 +35,81 @@ export type ApiCodeGenPluginOptions = {
 };
 
 /**
+ * Find the nearest tsconfig.json or jsconfig.json by searching upward.
+ * Bounded by process.cwd() — the Vite project root — to avoid picking up
+ * unrelated configs outside the project.
+ */
+async function findNearestTsConfig(filePath: string): Promise<string | null> {
+	let dir = path.dirname(path.resolve(filePath));
+	const rootDir = process.cwd();
+	const fsRoot = path.parse(dir).root;
+
+	while (true) {
+		for (const name of ['tsconfig.json', 'jsconfig.json']) {
+			const configPath = path.join(dir, name);
+			if (await fs.pathExists(configPath)) {
+				return configPath;
+			}
+		}
+
+		if (dir === rootDir || dir === fsRoot) break;
+
+		dir = path.dirname(dir);
+	}
+
+	return null;
+}
+
+/**
  * Run TypeScript type checking on generated file
  */
 async function runTypeCheck(filePath: string): Promise<string[]> {
 	const { execaCommand } = await import('execa');
 	const errors: string[] = [];
 
+	const resolvedPath = path.resolve(filePath);
+	const tsconfigPath = await findNearestTsConfig(resolvedPath);
+
+	if (!tsconfigPath) {
+		try {
+			await execaCommand(`npx tsc ${resolvedPath} --noEmit`, {
+				shell: true,
+			});
+		} catch (error) {
+			if (error instanceof Error) {
+				errors.push(error.message);
+			}
+		}
+		return errors;
+	}
+
+	const outputDir = path.dirname(resolvedPath);
+	const tempConfigName = `.${path.basename(resolvedPath).replace(/\.ts$/i, '')}.${Date.now()}.apicodegen.json`;
+	const tempConfigPath = path.join(outputDir, tempConfigName);
+	const extendsPath = path.relative(outputDir, tsconfigPath);
+
+	const tempConfig = {
+		extends: extendsPath,
+		compilerOptions: {
+			noEmit: true,
+		},
+		include: [path.basename(resolvedPath)],
+	};
+
 	try {
-		await execaCommand(`npx tsc ${filePath} --noEmit`, {
+		await fs.writeJson(tempConfigPath, tempConfig);
+		await execaCommand(`npx tsc --project "${tempConfigPath}" --noEmit`, {
 			shell: true,
 		});
 	} catch (error) {
 		if (error instanceof Error) {
 			errors.push(error.message);
+		}
+	} finally {
+		try {
+			await fs.remove(tempConfigPath);
+		} catch {
+			// ignore cleanup errors
 		}
 	}
 


### PR DESCRIPTION
修正 releasing skill 与 AGENTS.md 之间的不一致：

## 变更

1. **releasing skill** — 将原先的"直接 push main + push tag"流程改为走 PR 合并 + `gh release create`，与 AGENTS.md 一致
2. **AGENTS.md** — release flow 补充 changeset 步骤说明（`pnpm changeset add` + `pnpm changeset version`）

## 实际验证

本次 release v0.0.11 已按更新后的流程完整走通。`gh release create` 触发 CI 正常工作。
